### PR TITLE
Add templates

### DIFF
--- a/sim_functions.py
+++ b/sim_functions.py
@@ -17,40 +17,17 @@ def make_init_file(det_name     : str,
                    init_fname   : str,
                    config_fname : str
                   )            -> None :
+    # This contains a dictionary with all local vars, at this point only function parameters
+    params = locals()
 
-    # GEOMETRY
-    content  = f"/Geometry/RegisterGeometry {det_name}\n"
+    template_file = 'templates/init.mac' # Relative path!
+    template      = open(template_file).read()
 
-    # GENERATOR
-    content += f"/Generator/RegisterGenerator    SCINTGENERATOR\n"
+    content  = template.format(**params)
 
-    # ACTIONS
-    content += f"/Actions/RegisterRunAction      DEFAULT\n"
-    content += f"/Actions/RegisterEventAction    EL_SIM\n"
-    content += f"/Actions/RegisterTrackingAction DEFAULT\n"
-    content += f"/Actions/RegisterSteppingAction ANALYSIS\n"
-
-    # PHYSICS
-    content += f"/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4\n"
-    content += f"#/PhysicsList/RegisterPhysics G4EmExtraPhysics\n"
-    content += f"/PhysicsList/RegisterPhysics G4DecayPhysics\n"
-    content += f"/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics\n"
-    content += f"#/PhysicsList/RegisterPhysics G4HadronElasticPhysicsHP\n"
-    content += f"#/PhysicsList/RegisterPhysics G4HadronPhysicsQGSP_BERT_HP\n"
-    content += f"#/PhysicsList/RegisterPhysics G4StoppingPhysics\n"
-    content += f"#/PhysicsList/RegisterPhysics G4IonPhysics\n"
-    content += f"/PhysicsList/RegisterPhysics G4OpticalPhysics\n"
-    content += f"/PhysicsList/RegisterPhysics NexusPhysics\n"
-    content += f"/PhysicsList/RegisterPhysics G4StepLimiterPhysics\n"
-
-    # EXTRA CONFIGURATION
-    content += f"/nexus/RegisterMacro {config_fname}\n"
-    
-    #print(content)
     init_file = open(init_fname, 'w')
     init_file.write(content)
     init_file.close()
-
 
 
 ###

--- a/templates/init.mac
+++ b/templates/init.mac
@@ -1,0 +1,27 @@
+# GEOMETRY
+/Geometry/RegisterGeometry {det_name}
+
+# GENERATOR
+/Generator/RegisterGenerator    SCINTGENERATOR
+
+# ACTIONS
+/Actions/RegisterRunAction      DEFAULT
+/Actions/RegisterEventAction    EL_SIM
+/Actions/RegisterTrackingAction DEFAULT
+/Actions/RegisterSteppingAction ANALYSIS
+
+# PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+#/PhysicsList/RegisterPhysics G4EmExtraPhysics
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+#/PhysicsList/RegisterPhysics G4HadronElasticPhysicsHP
+#/PhysicsList/RegisterPhysics G4HadronPhysicsQGSP_BERT_HP
+#/PhysicsList/RegisterPhysics G4StoppingPhysics
+#/PhysicsList/RegisterPhysics G4IonPhysics
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics NexusPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+# EXTRA CONFIGURATION
+/nexus/RegisterMacro {config_fname}


### PR DESCRIPTION
Hola Javi,

He mirado un poco el código y tiene buena pinta. Lo que se me ocurre que se podría cambiar es sacar los templates fuera del código. Te he puesto un ejemplo de la idea en este PR.

Puedes tener los templates en ficheros aparte, en el ejemplo en `templates/init.mac` y en las funciones correspondientes leerlos y sustituir las variables con `format`.

Creo que puede ser más cómodo para tener distintas versiones de los configs, compararlos con otros jobs, etc. y creo que también mejora la legibilidad del código.

Se pueden añadir más cosas como en [este ejemplo](https://github.com/nextic/CERES/blob/master/ceres/templates.py) (CERES lo usamos para las producciones de Canfranc). Ahí tienes un diccionario con la lista de todos los templates y una función que carga el template que le pidas de la lista.

Quizás sea una cuestión de gustos, tampoco se si te compensa el trabajo de adaptar el código que ya está escrito, pero es una forma de desacoplar los ficheros de configuración y el código que genera los jobs.